### PR TITLE
Split up src/server/index.js

### DIFF
--- a/src/server/api/v1/exampleEndpoints.js
+++ b/src/server/api/v1/exampleEndpoints.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+
+router.get("/my_cool_endpoint", (req, res) => {
+	const data = { message: "my cool data" };
+	res.json(data);
+});
+
+router.get("/another_endpoint", (req, res) => {
+	const data = { message: "more data?!?", foo: "bar" };
+	res.json(data);
+});
+
+module.exports = router;

--- a/src/server/api/v1/v1.js
+++ b/src/server/api/v1/v1.js
@@ -1,0 +1,11 @@
+const express = require("express");
+const router = express.Router();
+
+const exampleEndpoints = require("./exampleEndpoints.js");
+
+router.use(exampleEndpoints);
+router.use((req, res) => {
+	res.sendStatus(404);
+});
+
+module.exports = router;

--- a/src/server/client.js
+++ b/src/server/client.js
@@ -1,0 +1,12 @@
+const path = require("path");
+const express = require("express");
+const router = express.Router();
+
+const { SITE_ROOT } = require("./config");
+const index = path.join(SITE_ROOT, "index.html");
+
+router.use((req, res) => {
+	res.sendFile(index);
+});
+
+module.exports = router;

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -1,0 +1,6 @@
+const path = require("path");
+
+const PORT = process.env.PORT || 8080;
+const SITE_ROOT = process.env.SITE_ROOT || path.join(__dirname, "../../dist");
+
+module.exports = { PORT, SITE_ROOT };

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,41 +1,14 @@
-const path = require("path");
 const express = require("express");
 const app = express();
 
-// Configure the server (or just use the defaults if they aren't set)
-const PORT = process.env.PORT || 8080;
-const SITE_ROOT = process.env.SITE_ROOT || path.join(__dirname, "../../dist");
+const { PORT, SITE_ROOT } = require("./config");
+const v1 = require("./api/v1/v1.js");
+const client = require("./client.js");
 
-// Serve any static files that match the requested URL
 app.use(express.static(SITE_ROOT));
+app.use("/v1", v1);
+app.use("*", client);
 
-// Otherwise, if the requested URL matches, serve the REST API endpoints
-app.get("/v1/my_cool_endpoint", (req, res) => {
-	const data = {
-		message: "my cool data"
-	};
-
-	res.json(data);
-});
-app.get("/v1/another_endpoint", (req, res) => {
-	const data = {
-		message: "more data?!?",
-		foo: "bar"
-	};
-
-	res.json(data);
-});
-app.get("/v1/*", (req, res) => {
-	res.sendStatus(404);
-});
-
-// Otherwise, no matter what the requested URL is, serve our React file - The React router will handle it!
-app.get("*", (req, res) => {
-	const index = path.join(SITE_ROOT, "index.html");
-	res.sendFile(index);
-});
-
-// Alright, let's start this server!
 app.listen(PORT, () => {
 	console.log(`Server listening on port ${PORT}`);
 });


### PR DESCRIPTION
Split up [src/server/index.js](https://github.com/tedski999/MLP-Job-Dashboard/blob/92137697f900b414fdab78d76058dad883aeff31/src/server/index.js) into index.js, client.js, config.js and an API directory containing the example endpoints. Closes #4.