### PR TITLE
Add development database

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,19 @@ A web-based dashboard application for the monitoring and alerting of automation 
 Requirements: `node.js` and `npm`.
 
 - Clone repository: `git clone git@github.com:tedski999/MLP-Job-Dashboard.git && cd MLP-Job-Dashboard`
-- Install dependencies: `npm install`
+- Install production dependencies: `npm install --production`
 - Start production server: `npm run prod`
 - Open `http://localhost:8080/` in browser
 
+You can also deploy this project as a Docker container with `npm run docker`.
+
 The development environment provides much better debugging support and automated rebuilding.
 You should use this instead of the production server when developing.
+- Install all dependencies: `npm install`
 - Start development environment: `npm run dev`
 - Open `http://localhost:8080/` in your browser.
-- Change (and save) either the client or server code.
-- Refresh your browser to see the changes.
 
-You can deploy this project as a Docker container with the provided scripts.
-This additionally requires that you have `docker` installed and running.
-- Build and run the Docker container with `npm run docker`.
-- Open `http://localhost/` in your browser.
+If you're using the development environment, you'll probably want to set up the development database as well.
+This will use `docker` to host a MariaDB database the project can query for test data.
+- Start development database: `npm run dev_db`
+- Initialise database with test data: `npm run dev_db:init <path to status_job.csv> <path to auto_queue.csv>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"express": "^4.17.3",
+				"mysql": "^2.18.1",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2"
 			},
@@ -2321,6 +2322,14 @@
 				"node": "*"
 			}
 		},
+		"node_modules/bignumber.js": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+			"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2869,6 +2878,11 @@
 			"bin": {
 				"semver": "bin/semver.js"
 			}
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"node_modules/cosmiconfig": {
 			"version": "7.0.1",
@@ -4953,6 +4967,11 @@
 			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
 			"dev": true
 		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5394,6 +5413,20 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
+		},
+		"node_modules/mysql": {
+			"version": "2.18.1",
+			"resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
+			"integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+			"dependencies": {
+				"bignumber.js": "9.0.0",
+				"readable-stream": "2.3.7",
+				"safe-buffer": "5.1.2",
+				"sqlstring": "2.3.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.1",
@@ -6140,6 +6173,11 @@
 				"renderkid": "^3.0.0"
 			}
 		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
 		"node_modules/prop-types": {
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6306,6 +6344,20 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"node_modules/readdirp": {
@@ -6548,8 +6600,7 @@
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
@@ -6856,12 +6907,28 @@
 			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
 			"dev": true
 		},
+		"node_modules/sqlstring": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
+			"integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A=",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/statuses": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/string-width": {
@@ -7447,8 +7514,7 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"node_modules/utila": {
 			"version": "0.4.0",
@@ -9460,6 +9526,11 @@
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 			"dev": true
 		},
+		"bignumber.js": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+			"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+		},
 		"binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -9875,6 +9946,11 @@
 					"dev": true
 				}
 			}
+		},
+		"core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"cosmiconfig": {
 			"version": "7.0.1",
@@ -11395,6 +11471,11 @@
 			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
 			"dev": true
 		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -11735,6 +11816,17 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
+		},
+		"mysql": {
+			"version": "2.18.1",
+			"resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
+			"integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+			"requires": {
+				"bignumber.js": "9.0.0",
+				"readable-stream": "2.3.7",
+				"safe-buffer": "5.1.2",
+				"sqlstring": "2.3.1"
+			}
 		},
 		"nanoid": {
 			"version": "3.3.1",
@@ -12276,6 +12368,11 @@
 				"renderkid": "^3.0.0"
 			}
 		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
 		"prop-types": {
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -12411,6 +12508,20 @@
 				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
 				"path-type": "^3.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readdirp": {
@@ -12598,8 +12709,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -12838,10 +12948,23 @@
 			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
 			"dev": true
 		},
+		"sqlstring": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
+			"integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
+		},
 		"statuses": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
 		},
 		"string-width": {
 			"version": "4.2.3",
@@ -13257,8 +13380,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"utila": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
 		"dev:build": "webpack --watch --progress --mode development",
 		"dev:serve": "nodemon --quiet --watch ./src/server --exec run-s lint:server serve",
 
+		"dev_db": "docker start --attach mlp-job-dashboard-db || docker run --name mlp-job-dashboard-db --env MYSQL_ROOT_PASSWORD=dev -p 3306:3306 mariadb:latest",
+		"dev_db:init": "node ./src/tools/init_dev_db.js",
+		"dev_db:stop": "docker stop mlp-job-dashboard-db",
+		"dev_db:delete": "docker rm mlp-job-dashboard-db",
+
 		"lint": "run-s lint:*",
 		"lint:client": "eslint ./src/client",
 		"lint:server": "eslint ./src/server",
@@ -32,6 +37,7 @@
 	"homepage": "https://github.com/tedski999/MLP-Job-Dashboard#readme",
 	"dependencies": {
 		"express": "^4.17.3",
+		"mysql": "^2.18.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/src/tools/init_dev_db.js
+++ b/src/tools/init_dev_db.js
@@ -1,0 +1,70 @@
+const mysql = require("mysql");
+const conn = mysql.createConnection({ user: "root", password: "dev" });
+
+const jobStatusFile = process.argv[2] || "job_status.csv";
+const autoQueueFile = process.argv[3] || "auto_queue.csv";
+
+conn.connect()
+
+// TODO(ted): dunno the names and types for the tables - ask ricardo
+console.log(`Initialising development database with data from ${jobStatusFile} and ${autoQueueFile}...`)
+conn.query("CREATE DATABASE dev");
+conn.query("USE dev");
+conn.query(`
+	CREATE TABLE job_status (
+		id INT NOT NULL,
+		name VARCHAR(255) NOT NULL
+	)`);
+conn.query(`
+	CREATE TABLE auto_queue (
+		job_id VARCHAR(255),
+		job_uid VARCHAR(255),
+		job_number VARCHAR(255),
+		job_ttl_seconds VARCHAR(255),
+		job_sub_status VARCHAR(255),
+		job_topic VARCHAR(255),
+		status_id VARCHAR(255),
+		created_by VARCHAR(255),
+		created_on VARCHAR(255),
+		updated_on VARCHAR(255),
+		group_name VARCHAR(255),
+		read_at VARCHAR(255),
+		read_from_ip VARCHAR(255),
+		read_by VARCHAR(255),
+		acked_at VARCHAR(255),
+		acked_from_ip VARCHAR(255),
+		acked_by VARCHAR(255),
+		completed_at VARCHAR(255),
+		completed_from_ip VARCHAR(255),
+		completed_by VARCHAR(255),
+		parent_job_id VARCHAR(255),
+		priority VARCHAR(255)
+	)`);
+
+conn.query(`
+	LOAD DATA LOCAL INFILE "${jobStatusFile}"
+		INTO TABLE job_status
+		COLUMNS TERMINATED BY ','
+		OPTIONALLY ENCLOSED BY '"'
+		ESCAPED BY '"'
+		LINES TERMINATED BY '\n';
+	`, err => {
+	if (err)
+		throw err;
+	console.log(`Successfully loaded data from ${jobStatusFile}`);
+});
+conn.query(`
+	LOAD DATA LOCAL INFILE "${autoQueueFile}"
+		INTO TABLE auto_queue
+		COLUMNS TERMINATED BY ','
+		OPTIONALLY ENCLOSED BY '"'
+		ESCAPED BY '"'
+		LINES TERMINATED BY '\n'
+		IGNORE 1 LINES;
+	`, err => {
+	if (err)
+		throw err;
+	console.log(`Successfully loaded data from ${autoQueueFile}`);
+});
+
+conn.end();


### PR DESCRIPTION
Added some commands and a script to quickly setup and control a MariaDB database with test data using Docker. This can be used in the development environment as a replacement for the real production database. MLP should be able to swap it out easily enough after our handover.

Closes #2 and #3.