### PR TITLE
Add status parameter to jobs API endpoint

### DIFF
--- a/src/client/Components/JobsGraph.js
+++ b/src/client/Components/JobsGraph.js
@@ -65,6 +65,9 @@ class JobsGraph extends React.Component {
 	async generateGraph() {
 		this.setState({ loading: true });
 
+		const after = new Date(this.state.filters.after);
+		const before = new Date(this.state.filters.before);
+
 		// Setup blank graph
 		this.freqCounts = {};
 		this.setState({ series: [{ name: "Jobs", data: [] }] });
@@ -73,11 +76,14 @@ class JobsGraph extends React.Component {
 				...prev.options,
 				xaxis: {
 					...prev.options.xaxis,
-					min: new Date(prev.filters.after).getTime(),
-					max: new Date(prev.filters.before).getTime()
+					min: after.getTime(),
+					max: before.getTime()
 				}
 			}
 		}));
+		for (const dt = new Date(after); dt <= before; dt.setHours(dt.getHours() + 1)) {
+			this.freqCounts[dt] = 0;
+		}
 
 		// Count frequencies of jobs as they're streamed in
 		await api.jobs("created_on", this.state.filters.after, this.state.filters.before, this.state.filters.group, this.state.filters.topic, this.state.filters.status, 0, jobs => {

--- a/src/client/Components/JobsGraph.js
+++ b/src/client/Components/JobsGraph.js
@@ -25,7 +25,10 @@ class JobsGraph extends React.Component {
 			series: [],
 			filters: {
 				after: twoMonthsAgo.toISOString().substring(0, 10),
-				before: now.toISOString().substring(0, 10)
+				before: now.toISOString().substring(0, 10),
+				group: "",
+				topic: "",
+				status: ""
 			},
 			options: {
 				chart: {
@@ -77,7 +80,7 @@ class JobsGraph extends React.Component {
 		}));
 
 		// Count frequencies of jobs as they're streamed in
-		await api.jobs("created_on", this.state.filters.after, this.state.filters.before, "", "", 0, jobs => {
+		await api.jobs("created_on", this.state.filters.after, this.state.filters.before, this.state.filters.group, this.state.filters.topic, this.state.filters.status, 0, jobs => {
 			jobs.forEach(job => {
 				const dt = new Date(job.created_on);
 				dt.setMinutes(0, 0, 0);
@@ -107,6 +110,24 @@ class JobsGraph extends React.Component {
 				<input
 					name="before" type="date"
 					value={this.state.filters.before}
+					onChange={this.handleFormInput}
+				/>
+				<label> Group: </label>
+				<input
+					name="group" type="text"
+					value={this.state.filters.group}
+					onChange={this.handleFormInput}
+				/>
+				<label> Topic: </label>
+				<input
+					name="topic" type="text"
+					value={this.state.filters.topic}
+					onChange={this.handleFormInput}
+				/>
+				<label> Status: </label>
+				<input
+					name="status" type="text"
+					value={this.state.filters.status}
 					onChange={this.handleFormInput}
 				/>
 				<br />

--- a/src/client/Components/JobsList.js
+++ b/src/client/Components/JobsList.js
@@ -26,7 +26,8 @@ class JobsList extends React.Component {
 				after: twoMonthsAgo.toISOString().substring(0, 10),
 				before: now.toISOString().substring(0, 10),
 				group: "",
-				topic: ""
+				topic: "",
+				status: ""
 			},
 		};
 	}
@@ -76,6 +77,7 @@ class JobsList extends React.Component {
 			this.state.filters.before,
 			this.state.filters.group,
 			this.state.filters.topic,
+			this.state.filters.status,
 			100, this.lastJobID);
 
 		this.setState({ jobs: [...this.state.jobs, ...newJobs] });
@@ -113,6 +115,12 @@ class JobsList extends React.Component {
 				<input
 					name="topic" type="text"
 					value={this.state.filters.topic}
+					onChange={this.handleFormInput}
+				/>
+				<label> Status: </label>
+				<input
+					name="status" type="text"
+					value={this.state.filters.status}
 					onChange={this.handleFormInput}
 				/>
 				<br />

--- a/src/client/api.js
+++ b/src/client/api.js
@@ -60,8 +60,8 @@ async function job(id) {
 // - Passing in a function implies that the data should be streamed. See fetchStream for more info.
 // - A string is used to skip straight to a matching job_id and any later data. This is much faster than paging.
 // - Finally, a number is simply used as a paging index. The data will start from index of (limit * page).
-async function jobs(columns, after, before, group, topic, limit, pagingMethod) {
-	const url = `/v1/jobs?c=${columns}&a=${after}&b=${before}&g=${group}&t=${topic}&l=${limit}`;
+async function jobs(columns, after, before, group, topic, status, limit, pagingMethod) {
+	const url = `/v1/jobs?c=${columns}&a=${after}&b=${before}&g=${group}&t=${topic}&r=${status}&l=${limit}`;
 	switch (typeof pagingMethod) {
 	case "function": return await fetchStream(url, pagingMethod);
 	case "string": return await fetchJSON(url + "&s=" + pagingMethod);

--- a/src/server/api/v1/auto_queue.js
+++ b/src/server/api/v1/auto_queue.js
@@ -45,12 +45,14 @@ router.get("/jobs", (req, res) => {
 	const limit = req.query.l || 0;
 	const page = req.query.p || -1;
 	const seek = req.query.s || "";
+	const status = req.query.r || "";
 	let query = `
 	SELECT ${columns} FROM auto_queue
 	WHERE created_on BETWEEN "${after}" AND "${before}"
 		${seek !== "" ? `AND job_id < "${seek}"` : ""}
 		${topic !== "" ? `AND job_topic LIKE "%${topic}%"` : ""}
 		${group !== "" ? `AND group_name LIKE "%${group}%"` : ""}
+		${status !== "" ? `AND status_id IN (${status})` : ""}
 	ORDER BY job_id DESC`;
 	if (limit > 0) {
 		query += (page >= 0)


### PR DESCRIPTION
Adds the "r=<status>" parameter to the `/v1/jobs` endpoint. This is used to filter the response by the status of the job. For example, `/v1/jobs?r=4,5` will return all the jobs which have a status_id equal to 4 or 5 (failed or timed-out).

Additionally added some example uses to the JobsList and JobsGraph.

Closes 40.